### PR TITLE
feat: show pkg name at the top of the chart

### DIFF
--- a/app/components/NPMChart.vue
+++ b/app/components/NPMChart.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { domToPng, domToSvg } from 'modern-screenshot'
 import { format } from 'date-fns'
-import { VisXYContainer, VisLine, VisAxis, VisArea, VisCrosshair, VisTooltip } from '@unovis/vue'
+import { VisXYContainer, VisLine, VisAxis, VisArea, VisCrosshair, VisTooltip, VisAnnotations } from '@unovis/vue'
 
 const cardRef = ref<HTMLElement | null>(null)
 const period = ref<Period>('monthly')
+const periodSelected = ref(0)
 const { width } = useElementSize(cardRef)
 
 const props = defineProps({
@@ -62,6 +63,7 @@ const xTicks = (i: number) => {
 }
 const template = (d: DataRecord) => `${formatDate(d.date)}: ${formatNumber(d.amount)}`
 function selectPeriod(index: number) {
+  periodSelected.value = index
   period.value = index === 0 ? 'monthly' : 'weekly'
 }
 async function download(type: 'png' | 'svg') {
@@ -83,7 +85,10 @@ const downloadsItems = [[
   { icon: 'i-ph-file-svg-light', label: '', click: () => download('svg') },
 ]]
 defineShortcuts({
-  d: () => downloadDropdownOpen.value = !downloadDropdownOpen.value
+  m: () => selectPeriod(0),
+  w: () => selectPeriod(1),
+  'd-p': () => download('png'),
+  'd-s': () => download('svg'),
 })
 </script>
 
@@ -95,6 +100,7 @@ defineShortcuts({
         <UTabs
           :items="[{ label: 'month' }, { label: 'week' }]"
           @change="selectPeriod"
+          v-model="periodSelected"
           :ui="{
             container: 'hidden',
             list: {
@@ -139,14 +145,11 @@ defineShortcuts({
       </div>
     </div>
     <div id="npm-chart" class="bg-gradient-to-b dark:from-primary-400 dark:to-primary-500 from-primary-300 to-primary-400 p-6 -mx-6 sm:rounded-lg">
-      <div class="text-gray-100 dark:text-gray-950 lowercase text-xs my-2">
-        {{props.pkg}}
-      </div>
       <VisXYContainer
         :data="data"
         class="h-96 bg-gray-100 dark:bg-gray-950 rounded"
         :width="width"
-        :padding="{ top: 10 }"
+        :padding="{ top: 15 }"
         :margin="{ bottom: 15, left: 10 }"
       >
         <VisLine :x="x" :y="y" color="rgb(var(--color-primary-DEFAULT))" />
@@ -156,6 +159,8 @@ defineShortcuts({
         <VisAxis type="y" :tick-format="(y) => formatNumberCompact(y)" />
 
         <VisCrosshair color="rgb(var(--color-primary-DEFAULT))" :template="template" />
+
+        <VisAnnotations :items="[{ x: 0, y: 350, content: { text: pkg, color: 'var(--vis-annotation-text-color)' } }]" />
 
         <VisTooltip />
       </VisXYContainer>
@@ -175,6 +180,8 @@ defineShortcuts({
   --vis-tooltip-background-color: #fff;
   --vis-tooltip-border-color: rgb(var(--color-gray-200));
   --vis-tooltip-text-color: rgb(var(--color-gray-900));
+
+  --vis-annotation-text-color: rgb(var(--color-primary-500));
 }
 
 .dark {
@@ -189,6 +196,7 @@ defineShortcuts({
     --vis-tooltip-background-color: rgb(var(--color-gray-900));
     --vis-tooltip-border-color: rgb(var(--color-gray-800));
     --vis-tooltip-text-color: #fff;
+    --vis-annotation-text-color: rgb(var(--color-primary-400));
   }
 }
 </style>

--- a/app/components/NPMChart.vue
+++ b/app/components/NPMChart.vue
@@ -139,6 +139,9 @@ defineShortcuts({
       </div>
     </div>
     <div id="npm-chart" class="bg-gradient-to-b dark:from-primary-400 dark:to-primary-500 from-primary-300 to-primary-400 p-6 -mx-6 sm:rounded-lg">
+      <div class="text-gray-100 dark:text-gray-950 lowercase text-xs my-2">
+        {{props.pkg}}
+      </div>
       <VisXYContainer
         :data="data"
         class="h-96 bg-gray-100 dark:bg-gray-950 rounded"

--- a/app/pages/[...pkg].vue
+++ b/app/pages/[...pkg].vue
@@ -21,14 +21,15 @@ if (import.meta.server) {
   }
 }
 defineShortcuts({
-  escape: () => navigateTo('/'),
+  'escape': () => navigateTo('/'),
+  '/': () => navigateTo('/'),
 })
 </script>
 
 <template>
   <div class="flex flex-col gap-1 w-full md:w-[680px] p-4 lg:p-0">
     <div class="flex justify-between">
-      <UTooltip text="Shortcut" :shortcuts="['esc']" :popper="{ placement: 'right' }">
+      <UTooltip text="Shortcut" :shortcuts="['/']" :popper="{ placement: 'right' }">
         <UButton
           to="/"
           variant="link"

--- a/app/pages/[...pkg].vue
+++ b/app/pages/[...pkg].vue
@@ -23,6 +23,7 @@ if (import.meta.server) {
 defineShortcuts({
   'escape': () => navigateTo('/'),
   '/': () => navigateTo('/'),
+  'meta_k': () => navigateTo('/'),
 })
 </script>
 


### PR DESCRIPTION
Add the name of the package in the final image. 

Since we already show the name up top, I was thinking if this would be better if it just existed when the image is being created instead of showing at all times

![image](https://github.com/user-attachments/assets/54454966-c723-4155-aa3a-5f037e8ee9b6)
