### PR TITLE
css: add flex-wrap

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -42,7 +42,7 @@ useSeoMeta({
         </template>
       </UInput>
     </form>
-    <div class="flex gap-1 mt-3">
+    <div class="flex flex-wrap justify-center gap-1 mt-3">
       <UButton
         v-for="pkg in randomPackages"
         :key="pkg"


### PR DESCRIPTION
When the buttons on the mobile page are too long, a scrollbar will appear
<img width="386" alt="image" src="https://github.com/user-attachments/assets/950874e7-fc40-4d86-8724-1b420e537d5d">
