### PR TITLE
feat: embeddable chart iframes

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -16,14 +16,9 @@ useSeoMeta({
 <template>
   <NuxtRouteAnnouncer />
   <NuxtLoadingIndicator color="rgb(var(--color-primary-DEFAULT))" />
-  <div class="flex flex-col items-center sm:justify-center sm:h-screen mx-auto">
+  <NuxtLayout>
     <NuxtPage />
-    <footer class="flex items-center justify-center bottom-0 w-full text-sm text-gray-500 px-6 pb-6" :class="$route.path === '/' ? 'fixed' : 'sm:fixed mt-6'">
-      <p class="text-center">
-        Made by <a href="https://x.com/atinux" target="_blank">Atinux</a><span class="inline-block mx-1.5">&middot;</span>Deployed on <a href="https://hub.nuxt.com/?utm_source=npm-chart">NuxtHub</a><span class="inline-block mx-1.5">&middot;</span>Source code on <a href="https://github.com/atinux/npm-chart" target="_blank">GitHub</a>
-      </p>
-    </footer>
-  </div>
+  </NuxtLayout>
 </template>
 
 <style lang="postcss">

--- a/app/components/NPMChart.vue
+++ b/app/components/NPMChart.vue
@@ -100,12 +100,22 @@ defineShortcuts({
   w: () => selectPeriod(1),
   'd-p': () => download('png'),
   'd-s': () => download('svg'),
+  e: () => open.value = !open.value
 })
 
 const url = computed(() => {
   return `https://npm.chart.dev/${props.pkg}?primary=${appConfig.ui.primary}&gray=${appConfig.ui.gray}&theme=${colorMode.value}`
 })
+
+const iframeEmbed = computed(() => {
+  return `<div style="padding:56.25% 0 0 0;position:relative;"><iframe src="${url.value.replace('npm.chart.dev/', 'npm.chart.dev/embed/')}" frameborder="0" allow="clipboard-write;" style="position:absolute;top:0;left:0;width:100%;height:100%;" title="NPM Chart"></iframe></div>`
+})
+
 const { copy, copied } = useClipboard({ source: url })
+
+const { copy: copyEmbed, copied: copiedEmbed } = useClipboard({ source: iframeEmbed })
+
+const embedModalOpen = ref(false)
 </script>
 
 <template>
@@ -163,6 +173,9 @@ const { copy, copied } = useClipboard({ source: url })
         <UTooltip :text="copied ? 'URL copied' : 'Share chart'" :popper="{ placement: 'top' }">
           <UButton variant="link" color="gray" :icon="copied ? 'i-heroicons-check' : 'i-heroicons-link'" size="xs" :padded="false" aria-label="Share chart" @click="copy()" class="ml-1" />
         </UTooltip>
+        <UTooltip text="Embed chart" :popper="{ placement: 'top' }">
+          <UButton variant="link" color="gray" icon="i-heroicons-code-bracket" size="xs" :padded="false" aria-label="Embed chart" @click="embedModalOpen = true" class="ml-1" />
+        </UTooltip>
       </div>
     </div>
     <div id="npm-chart" class="bg-gradient-to-b dark:from-primary-400 dark:to-primary-500 from-primary-300 to-primary-400 p-4 -mx-4 sm:p-6 sm:-mx-6 sm:rounded-lg">
@@ -193,6 +206,15 @@ const { copy, copied } = useClipboard({ source: url })
       </div>
     </div>
   </div>
+  <UModal v-model="embedModalOpen">
+    <div class="p-4">
+      <div class="text-sm text-gray-500 dark:text-gray-400 mb-3">
+        Copy the code below to embed the chart on your website.
+      </div>
+      <UTextarea :value="iframeEmbed" class="mb-4"></UTextarea>
+      <UButton color="gray" :icon="copiedEmbed ? 'i-heroicons-check' : 'i-heroicons-link'" size="xs" :label="copiedEmbed ? 'Copied!' : 'Copy embed code'" @click="copyEmbed()" class="ml-1" />
+    </div>
+  </UModal>
 </template>
 
 <style scoped>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="flex flex-col items-center sm:justify-center sm:h-screen mx-auto">
+    <slot />
+    <footer class="flex items-center justify-center bottom-0 w-full text-sm text-gray-500 px-6 pb-6" :class="$route.path === '/' ? 'fixed' : 'sm:fixed mt-6'">
+      <p class="text-center">
+        Made by <a href="https://x.com/atinux" target="_blank">Atinux</a><span class="inline-block mx-1.5">&middot;</span>Deployed on <a href="https://hub.nuxt.com/?utm_source=npm-chart">NuxtHub</a><span class="inline-block mx-1.5">&middot;</span>Source code on <a href="https://github.com/atinux/npm-chart" target="_blank">GitHub</a>
+      </p>
+    </footer>
+  </div>
+</template>

--- a/app/layouts/embed.vue
+++ b/app/layouts/embed.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="w-full h-full">
+    <div class="flex flex-col items-center sm:justify-center sm:h-screen mx-auto px-10 py-5">
+      <slot />
+      <footer class="flex flex-col items-center justify-center bottom-0 w-full text-sm text-gray-500 px-6 pb-3">
+        <p>
+          <a href="https://npm.chart.dev" target="_blank" class="flex items-center gap-1">
+            <img src="/favicon.ico" class="w-4 h-4" alt="">
+            npm.chart.dev
+          </a>
+        </p>
+      </footer>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style>
+html, body {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  height: 100%;
+}
+</style>

--- a/app/pages/embed/[...pkg].vue
+++ b/app/pages/embed/[...pkg].vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { setResponseHeaders } from 'h3'
+
+definePageMeta({
+  layout: 'embed',
+})
+
+const pkg = useRoute().params.pkg.join('/')
+const { data, pending } = await useFetch(`/api/${pkg}`, {
+  lazy: import.meta.client,
+})
+
+if (import.meta.server) {
+  setResponseHeaders(useRequestEvent(), {
+    'X-Frame-Options': 'ALLOW-FROM *',
+    'Content-Security-Policy': 'frame-ancestors *',
+  })
+}
+
+useSeoMeta({
+  title: () => `${data.value?.name || pkg} npm downloads - NPM Chart`,
+})
+</script>
+
+<template>
+  <div class="w-full h-full">
+    <h1 class="text-2xl font-bold">
+      <span v-if="data || pending" class="flex items-baseline gap-1.5">
+        <span class="lowercase">{{ data?.name || pkg }}</span>
+        <a
+          v-if="data"
+          class="text-sm text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400"
+          :href="`https://npmjs.com/package/${data.name}`"
+          target="_blank"
+        >
+          v{{ data.version }}
+        </a>
+        <USkeleton v-else-if="pending" class="w-20 h-4" />
+      </span>
+      <span v-else>Package not found</span>
+    </h1>
+    <p v-if="data">
+      {{ data.description }}
+    </p>
+    <USkeleton v-else-if="pending" class="w-full h-4 mt-2" />
+    <a
+      v-if="data?.homepage"
+      :href="data.homepage"
+      target="_blank"
+      class="text-primary hover:underline truncate"
+    >
+      {{ data.homepage.replace(/^https?:\/\//, '').replace(/\/$/, '') }}
+    </a>
+    <USkeleton v-else-if="pending" class="w-full h-4 mt-2" />
+
+    <div v-if="pending || data" class="mt-4">
+      <ClientOnly>
+        <NPMChart
+          v-if="data"
+          :pkg="data.name"
+          :data="data.downloads"
+          :total="data.total"
+        />
+        <USkeleton v-else-if="pending" class="w-full h-[468px]" />
+        <template #fallback>
+          <USkeleton class="w-full h-[468px]" />
+        </template>
+      </ClientOnly>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
Allows users to embed npm.chart.dev onto their sites.

There is some duplication of code, happy to clean this up if needed.

![image](https://github.com/user-attachments/assets/53902a3d-b7da-469b-a662-e3ee45a2af6b)

![image](https://github.com/user-attachments/assets/690e532c-7ea8-4d09-87b2-5510a67a93ca)
